### PR TITLE
Workaround: setting the header's zPosition while scrolling

### DIFF
--- a/CollectionViewBug.xcodeproj/project.pbxproj
+++ b/CollectionViewBug.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = CollectionViewBug/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MM.CollectionViewBug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -293,6 +294,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = CollectionViewBug/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MM.CollectionViewBug;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CollectionViewBug/ViewController.m
+++ b/CollectionViewBug/ViewController.m
@@ -47,4 +47,13 @@
     return view;
 }
 
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    
+    // Here is a workaround that positions the visible headers below the scroll indicator.
+    
+    for (UICollectionReusableView *header in [self.collectionView visibleSupplementaryViewsOfKind:UICollectionElementKindSectionHeader]) {
+        header.layer.zPosition = 0;
+    }
+}
+
 @end


### PR DESCRIPTION
Adding code to workaround the issue of having the scroll indicators go below the collection view's supplementary views.